### PR TITLE
Fix propagating cause in response serialization error

### DIFF
--- a/src/validationError.ts
+++ b/src/validationError.ts
@@ -1,5 +1,4 @@
 import { createError } from '@fastify/error';
-import {} from 'fastify';
 import type { FastifySchemaValidationError } from 'fastify/types/schema';
 import type { ZodError, ZodIssue, ZodIssueCode } from 'zod';
 
@@ -32,6 +31,7 @@ export class ResponseSerializationError extends createError(
     public url: string,
     options: { cause: ZodError },
   ) {
-    super(options);
+    super();
+    this.cause = options.cause;
   }
 }


### PR DESCRIPTION
It appears that the `super(options)` variant in the [[ResponseSerializationError](https://github.com/samchungy/fastify-zod-openapi/blob/main/src/validationError.ts#L24)](https://github.com/samchungy/fastify-zod-openapi/blob/main/src/validationError.ts#L24) doesn't propagate the cause correctly as it does with regular errors, resulting in an `undefined` value.

I suspect this is due to the `@fastify/error` implementation's method of extracting the actual cause, which expects the arguments to be in a specific order. A workaround is to assign the property directly on the instance.