### PR TITLE
Update serialization logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,16 @@ const customSerializerCompiler = createSerializerCompiler({
 });
 ```
 
+By default, this library assumes that if a response schema provided is not a Zod Schema, it is a JSON Schema and will naively pass it straight into `fast-json-stringify`. This will not work in conjunction with Fastify's schema registration.
+
+If you have other routes with response schemas which are not Zod Schemas, you can supply a `fallbackSerializer` to `createSerializerCompiler`.
+
+```ts
+const customSerializerCompiler = createSerializerCompiler({
+  fallbackSerializer: ({ schema, url, method }) => customSerializer(schema),
+});
+```
+
 Please note: the `responses`, `parameters` components do not appear to be supported by the `@fastify/swagger` library.
 
 ### Create Document Options

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@crackle/cli": "0.15.5",
     "@fastify/swagger": "9.4.2",
     "@fastify/swagger-ui": "5.2.1",
+    "@fastify/under-pressure": "9.0.3",
     "@types/node": "22.10.7",
     "eslint-plugin-zod-openapi": "1.0.0",
     "fastify": "5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@fastify/swagger-ui':
         specifier: 5.2.1
         version: 5.2.1
+      '@fastify/under-pressure':
+        specifier: 9.0.3
+        version: 9.0.3
       '@types/node':
         specifier: 22.10.7
         version: 22.10.7
@@ -885,6 +888,9 @@ packages:
 
   '@fastify/swagger@9.4.2':
     resolution: {integrity: sha512-WjSUu6QnmysLx1GeX7+oQAQUG/vBK5L8Qzcsht2SEpZiykpHURefMZpf+u3XbwSuH7TjeWOPgGIJIsEgj8AvxQ==}
+
+  '@fastify/under-pressure@9.0.3':
+    resolution: {integrity: sha512-uWzyFn9ThgGgynxyoX/kqgLtPtNBXXvQgN3U8fSRPNBS1y5mEZC/uCBRx03hXm9PDsQwTGN7qt83ItsHVQ0L4A==}
 
   '@formatjs/ecma402-abstract@2.0.0':
     resolution: {integrity: sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==}
@@ -6677,6 +6683,11 @@ snapshots:
       yaml: 2.7.0
     transitivePeerDependencies:
       - supports-color
+
+  '@fastify/under-pressure@9.0.3':
+    dependencies:
+      '@fastify/error': 4.0.0
+      fastify-plugin: 5.0.1
 
   '@formatjs/ecma402-abstract@2.0.0':
     dependencies:

--- a/src/serializerCompiler.test.ts
+++ b/src/serializerCompiler.test.ts
@@ -111,42 +111,6 @@ describe('serializerCompiler', () => {
     const app = fastify();
 
     app.register(UnderPressure, {
-      pressureHandler: () => {},
-      exposeStatusRoute: '/status/health-check',
-      healthCheck: () => Promise.resolve(true),
-    });
-    app.setSerializerCompiler(serializerCompiler);
-    app.post(
-      '/',
-      {
-        schema: {
-          response: {
-            200: {
-              type: 'object',
-              properties: {
-                jobId: { type: 'string' },
-              },
-            },
-          },
-        },
-      },
-      async (_req, res) =>
-        res.send({
-          jobId: '60002023',
-        }),
-    );
-
-    await app.ready();
-
-    const result = await app.inject().get('/status/health-check');
-
-    expect(result.json()).toEqual({ status: 'ok' });
-  });
-
-  it('should work without a schema', async () => {
-    const app = fastify();
-
-    app.register(UnderPressure, {
       exposeStatusRoute: '/status/health-check',
       healthCheck: () => Promise.resolve(true),
     });

--- a/src/serializerCompiler.test.ts
+++ b/src/serializerCompiler.test.ts
@@ -147,8 +147,6 @@ describe('serializerCompiler', () => {
     const app = fastify();
 
     app.register(UnderPressure, {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      pressureHandler: () => {},
       exposeStatusRoute: '/status/health-check',
       healthCheck: () => Promise.resolve(true),
     });

--- a/src/serializerCompiler.test.ts
+++ b/src/serializerCompiler.test.ts
@@ -74,6 +74,31 @@ describe('serializerCompiler', () => {
     expect(result.json()).toEqual({ jobId: '60002023' });
   });
 
+  it('should handle a route without a schema', async () => {
+    const app = fastify();
+
+    app.setSerializerCompiler(serializerCompiler);
+    app.post(
+      '/',
+      {
+        schema: {
+          response: {
+            200: {},
+          },
+        },
+      },
+      async (_req, res) =>
+        res.send({
+          jobId: '60002023',
+        }),
+    );
+    await app.ready();
+
+    const result = await app.inject().post('/');
+
+    expect(result.json()).toEqual({ jobId: '60002023' });
+  });
+
   it('should fail an invalid response', async () => {
     const app = fastify();
 

--- a/src/serializerCompiler.ts
+++ b/src/serializerCompiler.ts
@@ -6,6 +6,7 @@ import type { FastifySerializerCompiler } from 'fastify/types/schema';
 import type { ZodType, ZodTypeAny } from 'zod';
 import { createSchema } from 'zod-openapi';
 
+import { isZodType } from './transformer';
 import { ResponseSerializationError } from './validationError';
 
 export interface SerializerOptions {
@@ -16,6 +17,10 @@ export interface SerializerOptions {
 export const createSerializerCompiler =
   (opts?: SerializerOptions): FastifySerializerCompiler<ZodType> =>
   ({ schema, method, url }) => {
+    if (!isZodType(schema)) {
+      return opts?.stringify ?? JSON.stringify;
+    }
+
     let stringify = opts?.stringify;
     if (!stringify) {
       const { schema: jsonSchema, components } = createSchema(schema, {

--- a/src/serializerCompiler.ts
+++ b/src/serializerCompiler.ts
@@ -12,13 +12,17 @@ import { ResponseSerializationError } from './validationError';
 export interface SerializerOptions {
   components?: Record<string, ZodTypeAny>;
   stringify?: (value: unknown) => string;
+  fallbackSerializer?: FastifySerializerCompiler<ZodType>;
 }
 
 export const createSerializerCompiler =
   (opts?: SerializerOptions): FastifySerializerCompiler<ZodType> =>
-  ({ schema, method, url }) => {
+  (routeSchema) => {
+    const { schema, url, method } = routeSchema;
     if (!isZodType(schema)) {
-      return opts?.stringify ?? JSON.stringify;
+      return opts?.fallbackSerializer
+        ? opts.fallbackSerializer(routeSchema)
+        : fastJsonStringify(schema);
     }
 
     let stringify = opts?.stringify;


### PR DESCRIPTION
Defaults to passing the schema to `fast-json-stringify` if a schema provided is not a Zod Schema.

Resolves https://github.com/samchungy/fastify-zod-openapi/issues/225

This wouldn't have worked before 3.0.0 either but I guess this now works?