### PR TITLE
Fix Transformer Types

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -24,9 +24,11 @@ import {
   FASTIFY_ZOD_OPENAPI_CONFIG,
 } from './plugin';
 
-type Transform = FastifyDynamicSwaggerOptions['transform'];
+type Transform = NonNullable<FastifyDynamicSwaggerOptions['transform']>;
 
-type TransformObject = FastifyDynamicSwaggerOptions['transformObject'];
+type TransformObject = NonNullable<
+  FastifyDynamicSwaggerOptions['transformObject']
+>;
 
 type FastifyResponseSchema = ZodType | Record<string, unknown>;
 


### PR DESCRIPTION
Currently fastify-zod-openapi is using the [FastifyDynamicSwaggerOptions["transformer"]](https://github.com/fastify/fastify-swagger/blob/ab07ab3425389fd064df24e8381584d42e640bbc/index.d.ts#L127).
This is however an optional argument, whereas the Transformer should never be optional.

**Why is this important?**
This is a problem if you enable [exactOptionalPropertyTrue](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) in typescript as this will cause a type error.