### PR TITLE
fix(transformer): Support empty response body

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -2255,4 +2255,96 @@ describe('fastifyZodOpenApiTransformObject', () => {
       }
     `);
   });
+
+  it.each([
+    {
+      schema: z.void(),
+      description: 'void',
+    },
+    {
+      schema: z.undefined(),
+      description: 'undefined',
+    },
+    {
+      schema: z.null(),
+      description: 'null',
+    },
+  ])(
+    'should support empty responses with $description schema',
+    async ({ schema }) => {
+      const app = fastify();
+
+      app.setSerializerCompiler(serializerCompiler);
+      app.setValidatorCompiler(validatorCompiler);
+
+      await app.register(fastifyZodOpenApiPlugin);
+      await app.register(fastifySwagger, {
+        openapi: {
+          info: {
+            title: 'hello world',
+            version: '1.0.0',
+          },
+          openapi: '3.1.0',
+        },
+        ...fastifyZodOpenApiTransformers,
+      });
+      await app.register(fastifySwaggerUI, {
+        routePrefix: '/documentation',
+      });
+
+      app.withTypeProvider<FastifyZodOpenApiTypeProvider>().delete(
+        '/{id}',
+        {
+          schema: {
+            params: z.object({
+              id: z.string(),
+            }),
+            response: {
+              204: schema.meta({
+                description: 'The resource was deleted successfully.',
+              }),
+            },
+          } satisfies FastifyZodOpenApiSchema,
+        },
+        async (_req, res) => res.status(204).send(),
+      );
+      await app.ready();
+
+      const result = await app.inject().get('/documentation/json');
+
+      expect(result.json()).toMatchInlineSnapshot(`
+      {
+        "components": {
+          "schemas": {},
+        },
+        "info": {
+          "title": "hello world",
+          "version": "1.0.0",
+        },
+        "openapi": "3.1.0",
+        "paths": {
+          "/{id}": {
+            "delete": {
+              "parameters": [
+                {
+                  "in": "path",
+                  "name": "id",
+                  "required": true,
+                  "schema": {
+                    "type": "string",
+                  },
+                },
+              ],
+              "responses": {
+                "204": {
+                  "description": "The resource was deleted successfully.",
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+    },
+  );
 });

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -95,6 +95,22 @@ const createResponse = (
   for (const [key, value] of Object.entries(response)) {
     const unknownValue = value as unknown;
     if (isAnyZodType(unknownValue)) {
+      if (
+        'type' in unknownValue &&
+        (unknownValue.type === 'null' ||
+          unknownValue.type === 'undefined' ||
+          unknownValue.type === 'void')
+      ) {
+        responsesObject[key] = {
+          description:
+            'description' in unknownValue
+              ? unknownValue.description
+              : undefined,
+          type: 'null',
+        };
+        continue;
+      }
+
       if (!contentTypes?.length) {
         responsesObject[key] = registry.addSchema(
           unknownValue,


### PR DESCRIPTION
Currently, when you try to specify an empty response body with:

```ts
{
  schema: {
    response: {
      '204': {
        description: 'No content'
      }
    }
  }
}
```

The generated OpenAPI spec still produces a `content` key:

```yaml
responses:
  "204":
    description: No Content
    content:
      application/json:
        schema:
          description: No Content
```

The [expected OpenAPI spec](https://swagger.io/docs/specification/v3_0/describing-responses/#empty-response-body) is:

```yaml
responses:
  "204":
    description: No Content
```

Looks like for `fastify-swagger`, we need to specify `type: null`: https://github.com/fastify/fastify-swagger/pull/440