### PR TITLE
fix(transformer): Support empty response body with no content field

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -2256,63 +2256,48 @@ describe('fastifyZodOpenApiTransformObject', () => {
     `);
   });
 
-  it.each([
-    {
-      schema: z.void(),
-      description: 'void',
-    },
-    {
-      schema: z.undefined(),
-      description: 'undefined',
-    },
-    {
-      schema: z.null(),
-      description: 'null',
-    },
-  ])(
-    'should support empty responses with $description schema',
-    async ({ schema }) => {
-      const app = fastify();
+  it('should support empty responses with no content field', async () => {
+    const app = fastify();
 
-      app.setSerializerCompiler(serializerCompiler);
-      app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.setValidatorCompiler(validatorCompiler);
 
-      await app.register(fastifyZodOpenApiPlugin);
-      await app.register(fastifySwagger, {
-        openapi: {
-          info: {
-            title: 'hello world',
-            version: '1.0.0',
-          },
-          openapi: '3.1.0',
+    await app.register(fastifyZodOpenApiPlugin);
+    await app.register(fastifySwagger, {
+      openapi: {
+        info: {
+          title: 'hello world',
+          version: '1.0.0',
         },
-        ...fastifyZodOpenApiTransformers,
-      });
-      await app.register(fastifySwaggerUI, {
-        routePrefix: '/documentation',
-      });
+        openapi: '3.1.0',
+      },
+      ...fastifyZodOpenApiTransformers,
+    });
+    await app.register(fastifySwaggerUI, {
+      routePrefix: '/documentation',
+    });
 
-      app.withTypeProvider<FastifyZodOpenApiTypeProvider>().delete(
-        '/{id}',
-        {
-          schema: {
-            params: z.object({
-              id: z.string(),
-            }),
-            response: {
-              204: schema.meta({
-                description: 'The resource was deleted successfully.',
-              }),
+    app.withTypeProvider<FastifyZodOpenApiTypeProvider>().delete(
+      '/{id}',
+      {
+        schema: {
+          params: z.object({
+            id: z.string(),
+          }),
+          response: {
+            '204': {
+              description: 'The resource was deleted successfully.',
             },
-          } satisfies FastifyZodOpenApiSchema,
-        },
-        async (_req, res) => res.status(204).send(),
-      );
-      await app.ready();
+          },
+        } satisfies FastifyZodOpenApiSchema,
+      },
+      async (_req, res) => res.status(204).send(),
+    );
+    await app.ready();
 
-      const result = await app.inject().get('/documentation/json');
+    const result = await app.inject().get('/documentation/json');
 
-      expect(result.json()).toMatchInlineSnapshot(`
+    expect(result.json()).toMatchInlineSnapshot(`
       {
         "components": {
           "schemas": {},
@@ -2345,6 +2330,5 @@ describe('fastifyZodOpenApiTransformObject', () => {
         },
       }
     `);
-    },
-  );
+  });
 });

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -95,22 +95,6 @@ const createResponse = (
   for (const [key, value] of Object.entries(response)) {
     const unknownValue = value as unknown;
     if (isAnyZodType(unknownValue)) {
-      if (
-        'type' in unknownValue &&
-        (unknownValue.type === 'null' ||
-          unknownValue.type === 'undefined' ||
-          unknownValue.type === 'void')
-      ) {
-        responsesObject[key] = {
-          description:
-            'description' in unknownValue
-              ? unknownValue.description
-              : undefined,
-          type: 'null',
-        };
-        continue;
-      }
-
       if (!contentTypes?.length) {
         responsesObject[key] = registry.addSchema(
           unknownValue,
@@ -139,6 +123,19 @@ const createResponse = (
       );
 
       responsesObject[key] = contentSchemas[0];
+      continue;
+    }
+
+    if (
+      unknownValue &&
+      typeof unknownValue === 'object' &&
+      !('content' in unknownValue)
+    ) {
+      responsesObject[key] = {
+        description:
+          'description' in unknownValue ? unknownValue.description : undefined,
+        type: 'null',
+      };
       continue;
     }
 


### PR DESCRIPTION
Realised that it wasn't following the correct typing for `ZodOpenApiResponsesObject`. If you follow the typing of [ZodOpenApiResponsesObject](https://github.com/samchungy/zod-openapi/blob/0a8add45b9d4b5a4060243d5087a3b09e8ffe84f/src/create/document.ts#L41) then, to provide a `zod` schema of `z.undefined`, `z.void` or `z.null` you would need to provide a `content` key which wouldn't make sense. For example,

```ts
{
  '204': {
    description: 'No content',
    content: {
      '???': {
        schema: z.undefined()
      }
    }
  }
}
```