### PR TITLE
fix(zodv4): requests body examples

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -2064,6 +2064,318 @@ describe('fastifyZodOpenApiTransformObject', () => {
     `);
   });
 
+  it('should extract examples from components with a body', async () => {
+    const app = fastify();
+
+    app.setValidatorCompiler(validatorCompiler);
+
+    await app.register(fastifyZodOpenApiPlugin);
+    await app.register(fastifySwagger, {
+      openapi: {
+        info: {
+          title: 'hello world',
+          version: '1.0.0',
+        },
+        openapi: '3.1.0',
+      },
+      ...fastifyZodOpenApiTransformers,
+    });
+    await app.register(fastifySwaggerUI, {
+      routePrefix: '/documentation',
+    });
+
+    app.withTypeProvider<FastifyZodOpenApiTypeProvider>().post(
+      '/',
+      {
+        schema: {
+          body: z
+            .object({
+              id: z.number(),
+              text: z.string(),
+              isActive: z.boolean().optional(),
+            })
+            .meta({
+              examples: [
+                { id: 1, text: 'yolo', isActive: true },
+                { id: 2, text: 'bro', isActive: false },
+                { id: 3, text: 'cool' },
+              ],
+            }),
+        } satisfies FastifyZodOpenApiSchema,
+      },
+      async (_req, res) => {
+        res.send({
+          jobId: '60002023',
+        });
+      },
+    );
+
+    await app.ready();
+
+    const result = await app.inject().get('/documentation/json');
+
+    expect(result.json()).toMatchInlineSnapshot(`
+      {
+        "components": {
+          "schemas": {},
+        },
+        "info": {
+          "title": "hello world",
+          "version": "1.0.0",
+        },
+        "openapi": "3.1.0",
+        "paths": {
+          "/": {
+            "post": {
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "examples": {
+                      "Example1": {
+                        "value": {
+                          "id": 1,
+                          "isActive": true,
+                          "text": "yolo",
+                        },
+                      },
+                      "Example2": {
+                        "value": {
+                          "id": 2,
+                          "isActive": false,
+                          "text": "bro",
+                        },
+                      },
+                      "Example3": {
+                        "value": {
+                          "id": 3,
+                          "text": "cool",
+                        },
+                      },
+                    },
+                    "schema": {
+                      "properties": {
+                        "id": {
+                          "type": "number",
+                        },
+                        "isActive": {
+                          "type": "boolean",
+                        },
+                        "text": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "text",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                },
+                "required": true,
+              },
+              "responses": {
+                "200": {
+                  "description": "Default Response",
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it('should not extract examples if provided an empty examples array', async () => {
+    const app = fastify();
+
+    app.setValidatorCompiler(validatorCompiler);
+
+    await app.register(fastifyZodOpenApiPlugin);
+    await app.register(fastifySwagger, {
+      openapi: {
+        info: {
+          title: 'hello world',
+          version: '1.0.0',
+        },
+        openapi: '3.1.0',
+      },
+      ...fastifyZodOpenApiTransformers,
+    });
+    await app.register(fastifySwaggerUI, {
+      routePrefix: '/documentation',
+    });
+
+    app.withTypeProvider<FastifyZodOpenApiTypeProvider>().post(
+      '/',
+      {
+        schema: {
+          body: z
+            .object({
+              id: z.number(),
+              text: z.string(),
+              isActive: z.boolean().optional(),
+            })
+            .meta({
+              examples: [],
+            }),
+        } satisfies FastifyZodOpenApiSchema,
+      },
+      async (_req, res) => {
+        res.send({
+          jobId: '60002023',
+        });
+      },
+    );
+
+    await app.ready();
+
+    const result = await app.inject().get('/documentation/json');
+
+    expect(result.json()).toMatchInlineSnapshot(`
+      {
+        "components": {
+          "schemas": {},
+        },
+        "info": {
+          "title": "hello world",
+          "version": "1.0.0",
+        },
+        "openapi": "3.1.0",
+        "paths": {
+          "/": {
+            "post": {
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "properties": {
+                        "id": {
+                          "type": "number",
+                        },
+                        "isActive": {
+                          "type": "boolean",
+                        },
+                        "text": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "text",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                },
+                "required": true,
+              },
+              "responses": {
+                "200": {
+                  "description": "Default Response",
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it('should not extract examples if no examples are provided', async () => {
+    const app = fastify();
+
+    app.setValidatorCompiler(validatorCompiler);
+
+    await app.register(fastifyZodOpenApiPlugin);
+    await app.register(fastifySwagger, {
+      openapi: {
+        info: {
+          title: 'hello world',
+          version: '1.0.0',
+        },
+        openapi: '3.1.0',
+      },
+      ...fastifyZodOpenApiTransformers,
+    });
+    await app.register(fastifySwaggerUI, {
+      routePrefix: '/documentation',
+    });
+
+    app.withTypeProvider<FastifyZodOpenApiTypeProvider>().post(
+      '/',
+      {
+        schema: {
+          body: z
+            .object({
+              id: z.number(),
+              text: z.string(),
+              isActive: z.boolean().optional(),
+            })
+            .meta({}),
+        } satisfies FastifyZodOpenApiSchema,
+      },
+      async (_req, res) => {
+        res.send({
+          jobId: '60002023',
+        });
+      },
+    );
+
+    await app.ready();
+
+    const result = await app.inject().get('/documentation/json');
+
+    expect(result.json()).toMatchInlineSnapshot(`
+      {
+        "components": {
+          "schemas": {},
+        },
+        "info": {
+          "title": "hello world",
+          "version": "1.0.0",
+        },
+        "openapi": "3.1.0",
+        "paths": {
+          "/": {
+            "post": {
+              "requestBody": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "properties": {
+                        "id": {
+                          "type": "number",
+                        },
+                        "isActive": {
+                          "type": "boolean",
+                        },
+                        "text": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "text",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                },
+                "required": true,
+              },
+              "responses": {
+                "200": {
+                  "description": "Default Response",
+                },
+              },
+            },
+          },
+        },
+      }
+    `);
+  });
+
   it('should preserve existing components', async () => {
     const app = fastify();
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -458,8 +458,6 @@ const traverseObject = (
         }
       }
 
-      // Object.assign(schema, schemaObject) as OpenAPIV3_1.SchemaObject;
-
       if (
         (schema as oas31.SchemaObject)['x-fastify-zod-openapi-optional'] ===
         false

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -374,7 +374,9 @@ const traverseObject = (
         type: 'response' | 'requestBody';
         path: string[];
       },
-  schemaObject: (oas31.SchemaObject | oas31.ReferenceObject) & { examples?: unknown[] },
+  schemaObject: (oas31.SchemaObject | oas31.ReferenceObject) & {
+    examples?: unknown[];
+  },
   registry: ComponentRegistry,
 ):
   | OpenAPIV3_1.SchemaObject
@@ -435,17 +437,23 @@ const traverseObject = (
         requestBody.description = description;
       }
 
-      const { examples, ...schemaWithoutExamples } = schemaObject
+      const { examples, ...schemaWithoutExamples } = schemaObject;
       Object.assign(schema, schemaWithoutExamples);
 
-      if(examples !== undefined && Array.isArray(examples) && examples.length > 0) {
-        const examplesAsRecord = examples.reduce<Record<string, OpenAPIV3.ExampleObject>>((result, example, examplesIndex) => {
-          result[`Example${examplesIndex+1}`] = { value: example }
+      if (
+        examples !== undefined &&
+        Array.isArray(examples) &&
+        examples.length > 0
+      ) {
+        const examplesAsRecord = examples.reduce<
+          Record<string, OpenAPIV3.ExampleObject>
+        >((result, example, examplesIndex) => {
+          result[`Example${examplesIndex + 1}`] = { value: example };
 
-          return result
+          return result;
         }, {});
 
-        if(requestBody.content[contentType]) {
+        if (requestBody.content[contentType]) {
           requestBody.content[contentType].examples = examplesAsRecord;
         }
       }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -374,7 +374,7 @@ const traverseObject = (
         type: 'response' | 'requestBody';
         path: string[];
       },
-  schemaObject: oas31.SchemaObject | oas31.ReferenceObject,
+  schemaObject: (oas31.SchemaObject | oas31.ReferenceObject) & { examples?: unknown[] },
   registry: ComponentRegistry,
 ):
   | OpenAPIV3_1.SchemaObject
@@ -434,7 +434,23 @@ const traverseObject = (
       if (description) {
         requestBody.description = description;
       }
-      Object.assign(schema, schemaObject) as OpenAPIV3_1.SchemaObject;
+
+      const { examples, ...schemaWithoutExamples } = schemaObject
+      Object.assign(schema, schemaWithoutExamples);
+
+      if(examples !== undefined && Array.isArray(examples) && examples.length > 0) {
+        const examplesAsRecord = examples.reduce<Record<string, OpenAPIV3.ExampleObject>>((result, example, examplesIndex) => {
+          result[`Example${examplesIndex+1}`] = { value: example }
+
+          return result
+        }, {});
+
+        if(requestBody.content[contentType]) {
+          requestBody.content[contentType].examples = examplesAsRecord;
+        }
+      }
+
+      // Object.assign(schema, schemaObject) as OpenAPIV3_1.SchemaObject;
 
       if (
         (schema as oas31.SchemaObject)['x-fastify-zod-openapi-optional'] ===


### PR DESCRIPTION
Hello! Thank you for maintaining this lib 🙇🏻 

# Repro

https://github.com/jpb06/repro-zod-openapi-swagger-examples

# Issue

We encountered an issue with `fastify-zod-openapi` when migrating to `zod` v4. With `zod` v3, we defined our body schema like so:

```ts
export const postJobsBodySchema = z
  .object({
    jobId: z.string(),
  })
  .openapi({
    examples: [{ jobId: '123' }, { jobId: '456' }],
  })
```

which resulted in a schema looking like this:

```json
"requestBody": {
  "content": {
    "application/json": {
      "schema": {
        "type": "object",
        "properties": {
          "jobId": {
            "type": "string"
          }
        },
        "required": [
          "jobId"
        ]
      },
      "examples": {
        "example1": {
          "value": { "jobId": "123" }
        },
        "example2": {
          "value": { "jobId": "456" }
        }
      }
    }
  },
  "required": true
},
```

With `fastify-zod-openapi@5.3.2` and the switch to `zod` v4, doing something like this:

```ts
export const postJobsBodySchema = z
  .object({
    jobId: z.string(),
  })
  .meta({
    examples: [{ jobId: '123' }, { jobId: '456' }],
  });
```

results in the following schema:

```json
"requestBody": {
  "content": {
    "application/json": {
      "schema": {
        "examples": [
          { "jobId": "123" },
          { "jobId": "456" }
        ],
        "type": "object",
        "properties": {
          "jobId": {
            "type": "string"
          }
        },
        "required": [
          "jobId"
        ]
      },
    }
  },
  "required": true
},
```

As you can see, `examples` prop is in `schema` prop and has an invalid shape which causes examples to no longer appear in swagger (only first example is displayed as default).

<img width="3036" height="1728" alt="image" src="https://github.com/user-attachments/assets/64c21c67-5571-4790-b651-8fa02db64594" />

I was able to hack something by modifying `src/transformer.ts` in `fastify-zod-openapi`, which resolves the missing examples on swagger-ui:

<img width="2968" height="1724" alt="image" src="https://github.com/user-attachments/assets/d0161d37-fcec-461d-9f08-b15753e4e2d7" />


Could you please take a look and tell me if this is the right course of action to fix this issue?

Thanks!